### PR TITLE
解决android9.0及以下打开文件后按保存按钮无效的问题

### DIFF
--- a/QiuUTMT/Platforms/Android/AndroidManifest.xml
+++ b/QiuUTMT/Platforms/Android/AndroidManifest.xml
@@ -4,8 +4,7 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" 
-    android:maxSdkVersion="32"/>
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
     <!-- Required only if your app needs to access images or photos that other apps created -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <!-- Required only if your app needs to access videos that other apps created -->

--- a/QiuUTMT/Platforms/Android/AndroidManifest.xml
+++ b/QiuUTMT/Platforms/Android/AndroidManifest.xml
@@ -4,6 +4,8 @@
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" 
+    android:maxSdkVersion="32"/>
     <!-- Required only if your app needs to access images or photos that other apps created -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <!-- Required only if your app needs to access videos that other apps created -->


### PR DESCRIPTION
修改了AndroidManifest.xml，以解决android9.0及以下打开文件后按保存按钮无效的问题
抱歉，之前误删了我的仓库，导致pr提前关闭，现在再次提交pr
The AndroidManifest.xml was modified to solve the problem that pressing the save button after opening a file in android9.0 and below is invalid. 
Sorry, my warehouse was deleted by mistake before, which led to the early closure of pr, and now I submit pr again.